### PR TITLE
Fix line height in lists

### DIFF
--- a/documentation/assets/_scss/_components/_c-list-navigation.scss
+++ b/documentation/assets/_scss/_components/_c-list-navigation.scss
@@ -39,7 +39,7 @@ $au-list-navigation-border-color: $au-neutral-lighter !default;
 }
 
 .au-c-list-navigation__link {
-  @include au-font-size($au-base,.7);
+  @include au-font-size($au-base, 1.5);
   display: flex;
   align-items: center;
   font-family: $au-font;


### PR DESCRIPTION
Fixes the line height in the docs, this was a clear visual bug.