### PR TITLE
Allow jumping out and in styled rich text

### DIFF
--- a/documentation/_includes/layouts/component.liquid
+++ b/documentation/_includes/layouts/component.liquid
@@ -3,8 +3,10 @@ layout: default
 ---
 
 <section class="au-o-region-large au-d-theme-white">
-  <div class="au-o-layout au-c-content">
-    <h1>{{ title }}</h1>
+  <div class="au-o-layout">
+    <div class="au-c-content">
+      <h1>{{ title }}</h1>
+    </div>
     {% if references %}
     <h2 class="au-u-font au-u-h6">References:</h2>
     <ul class="au-u-margin-bottom-none">

--- a/documentation/_includes/layouts/documentation.liquid
+++ b/documentation/_includes/layouts/documentation.liquid
@@ -2,8 +2,11 @@
 layout: default
 ---
 
-<div class="au-o-layout au-c-content">
-  <h1>{{title}}</h1>
-  <hr>
+<div class="au-o-layout">
+  <div class="au-c-content">
+    <h1>{{title}}</h1>
+    <hr>
+  </div>
+
   {{content}}
 </div>

--- a/documentation/_pages/architecture.md
+++ b/documentation/_pages/architecture.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/guidelines/architecture/"
 ---
 
+<div class="au-c-content">
+
 ## Namespaces
 
 We use a global ```.au-``` namespace. Each layer of the ITCSS architecture is also namespaced according to the rules below.
@@ -19,3 +21,5 @@ We follow the ITCSS architecture
 6. **Components:** atoms and components (namespace: ```.au-c-```)
 7. **Utilities:** single function classes (namespace: ```.au-u-```)
 8. **Shame:** quickfixes & temporary hacks
+
+</div>

--- a/documentation/_pages/browser-support.md
+++ b/documentation/_pages/browser-support.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/guidelines/browser-support/"
 ---
 
+<div class="au-c-content">
+
 ## We develop for and test the following evergreen browsers:
 
 - Chrome (desktop)
@@ -12,3 +14,5 @@ permalink: "/guidelines/browser-support/"
 - Edge
 - Safari (desktop)
 - Safari (iOS)
+
+</div>

--- a/documentation/_pages/coding-principles.md
+++ b/documentation/_pages/coding-principles.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/guidelines/coding-principles/"
 ---
 
+<div class="au-c-content">
+
 Appuniversum is built upon the following principles. Please keep these in mind when contributing and/or using this framework.
 
 ## Low specificity
@@ -21,3 +23,5 @@ Avoid reliance on other bits.
 
 - **The Principle of Least Surprise:** make sure expectations are met, and nothing else
 - **Murphy’s Law:** Pick the option that is the most resilient, 
+
+</div>

--- a/documentation/_pages/coding-standards.md
+++ b/documentation/_pages/coding-standards.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/guidelines/coding-standards/"
 ---
 
+<div class="au-c-content">
+
 The following coding standards are based on YGDIR from [Mono](https://github.com/mono-company/ygdir)
 
 ## Style
@@ -238,3 +240,5 @@ This problem occurs in the HTML, not in the CSS. It is best to not mix up compon
   </div>
 </div>
 ````
+
+</div>

--- a/documentation/_pages/colors.md
+++ b/documentation/_pages/colors.md
@@ -4,8 +4,9 @@ layout: documentation
 permalink: "/foundation/colors/"
 ---
 
-​
-All color combinations should adhere to the [WCAG 2.0 AA standard](https://www.w3.org/TR/WCAG20/).
+​<div class="au-c-content">
+    All color combinations should adhere to the [WCAG 2.0 AA standard](https://www.w3.org/TR/WCAG20/).
+</div>
 
 <div class="au-o-box au-d-component">
   <ul class="au-o-grid au-o-grid--small u-margin-bottom">

--- a/documentation/_pages/contributing.md
+++ b/documentation/_pages/contributing.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/contributing/"
 ---
 
+<div class="au-c-content">
+
 ​First off, thank you for considering contributing to Appuniversum.
 
 Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. In return, they should reciprocate that respect in addressing your issue, assessing changes, and helping you finalize your pull requests.
@@ -33,3 +35,5 @@ When filing an issue, make sure to answer these five questions:
 3. What did you do?
 4. What did you expect to see?
 5. What did you see instead?
+
+</div>

--- a/documentation/_pages/index.md
+++ b/documentation/_pages/index.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/"
 ---
 
+<div class="au-c-content">
+
 A CSS framework for Flanders government applications.
 
 ## The goal of this project is to:
@@ -15,3 +17,5 @@ A CSS framework for Flanders government applications.
 ## References:
 - [Webuniversum V3](https://overheid.vlaanderen.be/webuniversum/v3/)
 - [LNE webcomponents](https://webcomponenten.omgeving.vlaanderen.be/doc/index.html)
+
+</div>

--- a/documentation/_pages/typography.md
+++ b/documentation/_pages/typography.md
@@ -4,6 +4,8 @@ layout: documentation
 permalink: "/foundation/typography/"
 ---
 
+<div class="au-c-content">
+
 ## Font sizes
 
 <div class="au-o-box au-d-component">
@@ -40,4 +42,6 @@ permalink: "/foundation/typography/"
   <h4 class="au-u-h2">Flanders Art Sans <span class="au-u-h4 au-u-font">(default style)</span></h4>
   <hr>
   <h4 class="au-u-h2 au-u-font-secondary">Flanders Art Serif <span class="au-u-h4 au-u-font">($au-u-font-secondary)</span></h4>
+</div>
+
 </div>


### PR DESCRIPTION
Allow jumping out and in styled rich text instead  of forcing it on every page.

Allow to jump in and out of .au-c-content class within docs content instead of having this as an overall class, with the risk of applying styles to children